### PR TITLE
Fix 1.15.2 Inventories

### DIFF
--- a/mccommons-config/mccommons-config-proxy/pom.xml
+++ b/mccommons-config/mccommons-config-proxy/pom.xml
@@ -29,13 +29,13 @@
         <dependency>
             <groupId>de.exceptionflug</groupId>
             <artifactId>protocolize-items</artifactId>
-            <version>1.5.3-SNAPSHOT</version>
+            <version>1.5.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>de.exceptionflug</groupId>
             <artifactId>protocolize-world</artifactId>
-            <version>1.5.3-SNAPSHOT</version>
+            <version>1.5.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/mccommons-holograms/dependency-reduced-pom.xml
+++ b/mccommons-holograms/dependency-reduced-pom.xml
@@ -120,6 +120,16 @@
       <artifactId>ProtocolLib</artifactId>
       <version>4.5.0</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>cglib-nodep</artifactId>
+          <groupId>cglib</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>BukkitExecutors</artifactId>
+          <groupId>com.comphenix.executors</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>de.exceptionflug</groupId>

--- a/mccommons-inventories/mccommons-inventories-api/pom.xml
+++ b/mccommons-inventories/mccommons-inventories-api/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>de.exceptionflug</groupId>
             <artifactId>protocolize-api</artifactId>
-            <version>1.5.3-SNAPSHOT</version>
+            <version>1.5.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/mccommons-inventories/mccommons-inventories-proxy/pom.xml
+++ b/mccommons-inventories/mccommons-inventories-proxy/pom.xml
@@ -24,13 +24,13 @@
         <dependency>
             <groupId>de.exceptionflug</groupId>
             <artifactId>protocolize-items</artifactId>
-            <version>1.5.3-SNAPSHOT</version>
+            <version>1.5.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>de.exceptionflug</groupId>
             <artifactId>protocolize-inventory</artifactId>
-            <version>1.5.3-SNAPSHOT</version>
+            <version>1.5.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>de.exceptionflug</groupId>
             <artifactId>protocolize-api</artifactId>
-            <version>1.5.3-SNAPSHOT</version>
+            <version>1.5.4-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/mccommons-plugin/mccommons-plugin-proxy/pom.xml
+++ b/mccommons-plugin/mccommons-plugin-proxy/pom.xml
@@ -95,19 +95,19 @@
         <dependency>
             <groupId>de.exceptionflug</groupId>
             <artifactId>protocolize-items</artifactId>
-            <version>1.5.3-SNAPSHOT</version>
+            <version>1.5.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>de.exceptionflug</groupId>
             <artifactId>protocolize-inventory</artifactId>
-            <version>1.5.3-SNAPSHOT</version>
+            <version>1.5.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>de.exceptionflug</groupId>
             <artifactId>protocolize-api</artifactId>
-            <version>1.5.3-SNAPSHOT</version>
+            <version>1.5.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/mccommons-plugin/mccommons-plugin-spigot/src/main/java/de/exceptionflug/mccommons/plugin/spigot/MCCommonsSpigotBootstrap.java
+++ b/mccommons-plugin/mccommons-plugin-spigot/src/main/java/de/exceptionflug/mccommons/plugin/spigot/MCCommonsSpigotBootstrap.java
@@ -27,7 +27,6 @@ import de.exceptionflug.mccommons.inventories.spigot.utils.ReflectionUtil;
 import de.exceptionflug.mccommons.inventories.spigot.utils.ServerVersionProvider;
 import de.exceptionflug.mccommons.plugin.spigot.commands.ConfigReloadCommand;
 import de.exceptionflug.mccommons.plugin.spigot.commands.HologramReloadCommand;
-import de.exceptionflug.mccommons.plugin.spigot.commands.SchafeCommand;
 import de.exceptionflug.mccommons.plugin.spigot.converter.ItemStackConverter;
 import de.exceptionflug.mccommons.plugin.spigot.converter.PlayerConverter;
 import org.bukkit.Bukkit;
@@ -87,8 +86,6 @@ public class MCCommonsSpigotBootstrap {
 
             final ConfigWrapper rapper = ConfigFactory.create(new File("plugins/mccommons/commands/CommandFramework.yml"), SpigotConfig.class);
             final SpigotCommandFramework commandFramework = new SpigotCommandFramework(rapper);
-
-            commandFramework.registerCommand(new SchafeCommand());
 
             Bukkit.getPluginManager().registerEvents(new InventoryListener(), plugin);
             plugin.getCommand("mcrl").setExecutor(new ConfigReloadCommand());


### PR DESCRIPTION
Updating to Protocolize 1.5.4-SNAPSHOT fixes Bungeecord Inventories from not showing to 1.15.2 clients without the use of ViaVersion on the Proxy.

![image](https://user-images.githubusercontent.com/1311244/78872951-6283be80-7a8d-11ea-93ab-a35e4c030ccf.png)
